### PR TITLE
feat: OGP画像をいい感じの改行で表示する

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,14 @@
     "preview": "wrangler pages dev dist",
     "deploy": "$npm_execpath run build && wrangler pages deploy dist",
     "check": "biome check ./src",
-    "check:fix" : "biome check --apply ./src"
+    "check:fix": "biome check --apply ./src"
   },
   "dependencies": {
     "@hono/react-renderer": "0.2.0",
     "@yamada-ui/fontawesome": "1.0.26",
     "@yamada-ui/markdown": "1.0.27",
     "@yamada-ui/react": "1.3.9",
+    "budoux": "^0.6.2",
     "hono": "4.3.2",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/src/articles/infra/ogps.repository.tsx
+++ b/src/articles/infra/ogps.repository.tsx
@@ -3,11 +3,16 @@ import path from "node:path";
 import satori from "satori";
 import sharp from "sharp";
 import { BLOG_TITLE } from "../../constants";
+import { loadDefaultJapaneseParser } from "budoux";
 
 const createOGP = async (title: string): Promise<Buffer> => {
   const robotoArrayBuffer = await fs.readFile(
-    path.resolve(path.join("font"), "NotoSansJP-Bold.ttf"),
+    path.resolve(path.join("font"), "NotoSansJP-Bold.ttf")
   );
+
+  const parser = loadDefaultJapaneseParser();
+
+  const wakachigakiTitle = parser.parse(title);
   const svg = await satori(
     <div
       style={{
@@ -38,9 +43,15 @@ const createOGP = async (title: string): Promise<Buffer> => {
           style={{
             fontSize: "50px",
             fontWeight: 700,
+            display: "flex",
+            justifyContent: "center",
+            flexWrap: "wrap",
+            width: "70%",
           }}
         >
-          {title}
+          {wakachigakiTitle.map((word) => (
+            <span style={{ display: "block" }}>{word}</span>
+          ))}
         </span>
         <span
           style={{
@@ -64,7 +75,7 @@ const createOGP = async (title: string): Promise<Buffer> => {
           style: "normal",
         },
       ],
-    },
+    }
   );
 
   return sharp(Buffer.from(svg)).png().toBuffer();

--- a/src/articles/infra/ogps.repository.tsx
+++ b/src/articles/infra/ogps.repository.tsx
@@ -11,8 +11,8 @@ const createOGP = async (title: string): Promise<Buffer> => {
   );
 
   const parser = loadDefaultJapaneseParser();
-
   const wakachigakiTitle = parser.parse(title);
+
   const svg = await satori(
     <div
       style={{


### PR DESCRIPTION
これが、
<img width="1186" alt="スクリーンショット 2024-05-21 23 59 14" src="https://github.com/takuminish/takuminishBlogV3/assets/30888611/c9921897-4266-42d7-b7b6-85b598f56693">

こう
<img width="746" alt="スクリーンショット 2024-05-21 23 58 31" src="https://github.com/takuminish/takuminishBlogV3/assets/30888611/de18f2b1-9179-47c1-b174-bdda3239a6b2">
